### PR TITLE
🐛 Fix: Handle invalid JSON in tool input

### DIFF
--- a/src/CopilotApiGateway.ts
+++ b/src/CopilotApiGateway.ts
@@ -3406,14 +3406,26 @@ export class CopilotApiGateway implements vscode.Disposable {
 						currentText = '';
 					}
 					const toolCallId = `toolu_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
-					contentBlocks.push({
-						type: 'tool_use',
-						id: toolCallId,
-						name: part.name,
-						input: typeof part.input === 'string'
-							? (JSON.parse(part.input || '{}') as Record<string, unknown>)
-							: ((part.input as Record<string, unknown>) || {})
-					});
+
+let parsedInput: Record<string, unknown>;
+
+if (typeof part.input === 'string') {
+	try {
+		parsedInput = JSON.parse(part.input || '{}') as Record<string, unknown>;
+	} catch (e) {
+		console.error('Invalid JSON in tool input:', part.input);
+		parsedInput = {};
+	}
+} else {
+	parsedInput = (part.input as Record<string, unknown>) || {};
+}
+
+contentBlocks.push({
+	type: 'tool_use',
+	id: toolCallId,
+	name: part.name,
+	input: parsedInput
+});
 				} else {
 					const textValue = this.extractTextFromPart(part);
 					if (textValue) { currentText += textValue; }


### PR DESCRIPTION
Fixes #66 

### 📜 Description

This PR fixes a crash caused by invalid JSON passed to `JSON.parse` when handling tool inputs.

Previously, the code assumed all `part.input` values were valid JSON strings. When invalid JSON was received, it caused an unhandled exception, resulting in a server crash.

### ✅ Solution

- Wrapped `JSON.parse` in a `try/catch` block
- Added fallback to an empty object `{}` when parsing fails
- Logged invalid input for debugging purposes

### 🧪 Result

- Prevents runtime crashes
- Ensures graceful handling of malformed input
- Keeps behavior consistent with other JSON parsing in the codebase

### 🚀 Impact

Improves robustness and reliability of the API when dealing with unexpected or malformed tool inputs.